### PR TITLE
DES-976 Updating java 8 version to 202 for kafka-connect-jdbc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         timestamps()
     }
     tools {
-       jdk 'oracle-java8u162-jdk'
+       jdk 'oracle-java8u202-jdk'
        maven 'apache-maven-3.5.0'
     }
     triggers {


### PR DESCRIPTION
Description of change
Updating CI Slave Java version 8 from 162 to 202

Motivation
Currently blocking PR builds to pass due to recent java version cleanup