### PR TITLE
DEVPROD-1736 Set owner

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,23 @@
+# catalog-info.yml
+# This file contains metadata for backstage
+# Read more about available fields and annotations:
+# https://github.com/tradeshift/backstage
+#
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: kafka-connect-jdbc
+  description: |
+    This library makes it easy to configure RabbitMQ for use with Spring
+  annotations:
+    github.com/project-slug: Tradeshift/kafka-connect-jdbc # GitHub project name
+    sentry.io/project-slug: kafka-connect-jdbc # Name in sentry for enabling Sentry integration
+    backstage.io/kubernetes-id: kafka-connect-jdbc # Kubernetes app id, this is a Kubernetes label from the deployment of your service look for ex. app: backstage
+    # pagerduty.com/integration-key: a834115a04c748a5befc777442e209b8 # PagerDuty integration id from the service. Can be created in Pagerduty under Service Discovery -> Service name -> Integrations tab -> Add new integration. Please use the Events API v2, this might require you to chnage 'Alert and Incident Settings' on the 'Integrations tab' page.
+    sonarqube.org/project-key: kafka-connect-jdbc # Name of the project in SonarQube
+  tags:
+    - java
+spec:
+  type: service
+  owner: ml-team
+  lifecycle: production


### PR DESCRIPTION
Motivation: All repos should have a team owning them

From commit history, this seem to be owned by the ml-team, but it might not be deployed anywhere anymore: https://livegrep.ts.sv/search/backend?q=kafka-connect-jdbc&fold_case=auto&regex=false&context=true